### PR TITLE
Remove debug visual indicator in production

### DIFF
--- a/components/events/IntersectionTrigger.tsx
+++ b/components/events/IntersectionTrigger.tsx
@@ -41,7 +41,9 @@ export function IntersectionTrigger({
       data-testid="intersection-trigger"
     >
       {/* Visual indicator for debugging (can be removed in production) */}
-      <div className="h-px bg-purple-500/20 w-full" />
+      {process.env.NODE_ENV === 'development' && (
+        <div className="h-px bg-purple-500/20 w-full" />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
The intersection trigger component rendered a 1px purple line for debugging purposes. This PR conditionally renders this indicator so it only appears in development environments, keeping the production UI clean while maintaining the debugging tool for developers.

---
*PR created automatically by Jules for task [16236364634318603684](https://jules.google.com/task/16236364634318603684) started by @cosimochellini*